### PR TITLE
Promote various logged warnings about property value ordering to errors

### DIFF
--- a/incident-ef7/src/incident/event.py
+++ b/incident-ef7/src/incident/event.py
@@ -1,7 +1,7 @@
-import logging
 from collections import OrderedDict
 
 import stix2
+from stix2.exceptions import ObjectConfigurationError
 from stix2.properties import (BooleanProperty, EnumProperty, ListProperty,
                               OpenVocabProperty, ReferenceProperty,
                               StringProperty, TimestampProperty)
@@ -57,7 +57,6 @@ class EventEntry(_STIXBase21):
 class Event:
     def _check_object_constraints(self):
         super()._check_object_constraints()
-        log = logging.getLogger(__name__)
 
         validate_event_sequence(self.get("subevents"))
 
@@ -65,8 +64,8 @@ class Event:
         end_time = self.get('end_time')
 
         if start_time is not None and end_time is not None:
-            if start_time > end_time:
-                log.warning(
-                    'event start time is later than end time: %s > %s',
-                    start_time, end_time
+            if start_time >= end_time:
+                raise ObjectConfigurationError(
+                    'event start time is equal to or later than end time:'
+                    ' {} >= {}'.format(start_time, end_time)
                 )

--- a/incident-ef7/src/incident/impact.py
+++ b/incident-ef7/src/incident/impact.py
@@ -1,4 +1,3 @@
-import logging
 from collections import OrderedDict
 
 import stix2
@@ -95,7 +94,6 @@ class IntegrityImpactExt:
 class MonetaryImpactExt:
     def _check_object_constraints(self):
         super()._check_object_constraints()
-        log = logging.getLogger(__name__)
 
         self._check_properties_dependency(
             [
@@ -134,11 +132,11 @@ class MonetaryImpactExt:
             )
 
         if min_amount is not None and max_amount is not None:
-            log.warning(
-                "monetary impact min_amount is greater than max_amount:"
-                " %d > %d",
-                min_amount, max_amount
-            )
+            if min_amount > max_amount:
+                raise ObjectConfigurationError(
+                    "monetary impact min_amount is greater than max_amount:"
+                    " {} > {}".format(min_amount, max_amount)
+                )
 
 
 @stix2.CustomExtension(
@@ -196,7 +194,6 @@ IMPACT_EXTENSION_DEFINITION_ID = 'extension-definition--7cc33dd6-f6a1-489b-98ea-
 class Impact:
     def _check_object_constraints(self):
         super()._check_object_constraints()
-        log = logging.getLogger(__name__)
 
         self._check_properties_dependency(["end_time"], ["superseded_by_ref"])
 
@@ -204,10 +201,10 @@ class Impact:
         end_time = self.get('end_time')
 
         if start_time is not None and end_time is not None:
-            if start_time > end_time:
-                log.warning(
-                    'impact start time is later than end time: %s > %s',
-                    start_time, end_time
+            if start_time >= end_time:
+                raise ObjectConfigurationError(
+                    'impact start time is equal to or later than end time:'
+                    ' {} > {}'.format(start_time, end_time)
                 )
 
         impact_category = self["impact_category"]

--- a/incident-ef7/src/incident/task.py
+++ b/incident-ef7/src/incident/task.py
@@ -1,7 +1,7 @@
-import logging
 from collections import OrderedDict
 
 import stix2
+from stix2.exceptions import ObjectConfigurationError
 from stix2.properties import (BooleanProperty, EnumProperty, IntegerProperty,
                               ListProperty, OpenVocabProperty,
                               ReferenceProperty, StringProperty,
@@ -59,7 +59,6 @@ class TaskEntry(_STIXBase21):
 class Task:
     def _check_object_constraints(self):
         super()._check_object_constraints()
-        log = logging.getLogger(__name__)
 
         util.validate_task_sequence(self.get("subtasks"))
 
@@ -67,8 +66,8 @@ class Task:
         end_time = self.get('end_time')
 
         if start_time is not None and end_time is not None:
-            if start_time > end_time:
-                log.warning(
-                    'task start time is later than end time: %s > %s',
-                    start_time, end_time
+            if start_time >= end_time:
+                raise ObjectConfigurationError(
+                    'task start time is equal to or later than end time:'
+                    ' {} >= {}'.format(start_time, end_time),
                 )

--- a/incident-ef7/tests/incident/test_event.py
+++ b/incident-ef7/tests/incident/test_event.py
@@ -164,3 +164,20 @@ def test_subevents_undefined_next_event():
                 )
             ]
         )
+
+
+def test_event_time_order():
+    with pytest.raises(stix2.exceptions.ObjectConfigurationError):
+        Event(
+            status=vocab.EVENT_STATUS_ONGOING,
+            start_time="1991-04-02T03:26:36.2678Z",
+            end_time="1990-08-31T08:14:47.289721Z"
+        )
+
+    # Try with exactly equal times as well; spec implies this should error
+    with pytest.raises(stix2.exceptions.ObjectConfigurationError):
+        Event(
+            status=vocab.EVENT_STATUS_ONGOING,
+            start_time="1991-04-02T03:26:36.2678Z",
+            end_time="1991-04-02T03:26:36.2678Z"
+        )

--- a/incident-ef7/tests/incident/test_impact.py
+++ b/incident-ef7/tests/incident/test_impact.py
@@ -123,6 +123,33 @@ def test_superseded_by_ref_dependency():
         )
 
 
+def test_impact_time_order():
+    with pytest.raises(ObjectConfigurationError):
+        Impact(
+            impact_category="availability-ext",
+            start_time="1994-08-18T03:22:22.2371Z",
+            end_time="1980-02-14T01:44:38.7912Z",
+            extensions={
+                "availability-ext": AvailabilityImpactExt(
+                    availability_impact=25
+                )
+            }
+        )
+
+    # Try with exactly equal times as well; spec implies this should error
+    with pytest.raises(ObjectConfigurationError):
+        Impact(
+            impact_category="availability-ext",
+            start_time="1994-08-18T03:22:22.2371Z",
+            end_time="1994-08-18T03:22:22.2371Z",
+            extensions={
+                "availability-ext": AvailabilityImpactExt(
+                    availability_impact=25
+                )
+            }
+        )
+
+
 def test_confidentiality_impact_information_type_dependency():
     with pytest.raises(ObjectConfigurationError):
         ConfidentialityImpactExt(
@@ -220,8 +247,8 @@ def test_monetary_impact_maximal():
         conversion_time="2001-03-04T23:12:02.34562Z",
         currency="ABC",
         currency_actual="DEF",
-        max_amount=1.2,
-        min_amount=3.4
+        max_amount=3.4,
+        min_amount=1.2
     )
 
 
@@ -278,6 +305,30 @@ def test_monetary_impact_dependency_currency_actual():
             max_amount=10000,
             currency_actual="XYZ"
         )
+
+
+def test_monetary_impact_min_max_amount_order():
+    with pytest.raises(ObjectConfigurationError):
+        MonetaryImpactExt(
+            variety=vocab.MONETARY_IMPACT_RANSOM_DEMAND,
+            conversion_rate=1.4,
+            conversion_time="2001-03-04T23:12:02.34562Z",
+            currency="ABC",
+            currency_actual="DEF",
+            max_amount=1.2,
+            min_amount=3.4
+        )
+
+    # equal min/max_amount should be okay
+    MonetaryImpactExt(
+        variety=vocab.MONETARY_IMPACT_RANSOM_DEMAND,
+        conversion_rate=1.4,
+        conversion_time="2001-03-04T23:12:02.34562Z",
+        currency="ABC",
+        currency_actual="DEF",
+        max_amount=1.2,
+        min_amount=1.2
+    )
 
 
 def test_physical_impact_dependency_asset_type():

--- a/incident-ef7/tests/incident/test_task.py
+++ b/incident-ef7/tests/incident/test_task.py
@@ -170,3 +170,20 @@ def test_subtasks_undefined_next_step():
                 )
             ]
         )
+
+
+def test_task_time_order():
+    with pytest.raises(ObjectConfigurationError):
+        Task(
+            outcome=vocab.TASK_OUTCOME_SUCCESSFUL,
+            start_time="1997-04-13T20:09:19.1697Z",
+            end_time="1991-04-28T18:31:00.5648Z"
+        )
+
+    # Try with exactly equal times as well; spec implies this should error
+    with pytest.raises(ObjectConfigurationError):
+        Task(
+            outcome=vocab.TASK_OUTCOME_SUCCESSFUL,
+            start_time="1997-04-13T20:09:19.1697Z",
+            end_time="1997-04-13T20:09:19.1697Z"
+        )

--- a/incident-ef7/tests/incident/test_util.py
+++ b/incident-ef7/tests/incident/test_util.py
@@ -1,0 +1,21 @@
+import pytest
+import incident.util as util
+from stix2.exceptions import InvalidValueError
+
+
+def test_check_open_bounds_high():
+    with pytest.raises(InvalidValueError):
+        # any old class and prop name will do
+        util.check_open_bounds(list, "foo", 2, max_exc=2)
+
+    with pytest.raises(InvalidValueError):
+        util.check_open_bounds(list, "foo", 2, max_exc=1)
+
+
+def test_check_open_bounds_low():
+    with pytest.raises(InvalidValueError):
+        # any old class and prop name will do
+        util.check_open_bounds(list, "foo", 1, min_exc=1)
+
+    with pytest.raises(InvalidValueError):
+        util.check_open_bounds(list, "foo", 1, min_exc=2)

--- a/incident-ef7/tox.ini
+++ b/incident-ef7/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,style
+envlist = py{38,39,310,311,312},style
 
-[testenv]
+[testenv:py{38,39,310,311,312}]
 extras = dev
 deps =
   pytest-cov
@@ -9,8 +9,9 @@ deps =
 commands =
   python -m pytest --cov=incident --cov-report=term-missing tests/
 
-[style]
+[testenv:style]
+skip_install = true
 deps =
   ruff
 commands =
-  ruff . --line-length 160
+  ruff check ./src ./tests


### PR DESCRIPTION
This PR promotes logged warnings regarding ordering of various property values to raised exceptions, since the spec has added new requirements.

Also:
- Add a couple more unit tests to raise unit test coverage to 100%.
- Fix tox.ini so that the style check runs properly.
