### PR TITLE
Add a max-line-length setting for ruff checking, to allow longer lines.

### DIFF
--- a/incident-ef7/pyproject.toml
+++ b/incident-ef7/pyproject.toml
@@ -16,5 +16,8 @@ dev = ["pytest", "tox"]
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"
 
+[tool.ruff.lint]
+extend-select = ["E501"]
+
 [tool.ruff.lint.pycodestyle]
 max-line-length = 160

--- a/incident-ef7/pyproject.toml
+++ b/incident-ef7/pyproject.toml
@@ -15,3 +15,6 @@ dev = ["pytest", "tox"]
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 160


### PR DESCRIPTION
The `line-length` setting is used by the ruff formatter, whereas `max-line-length` seemed specific to the ruff checker.  So the latter seemed more appropriate for us.

See:

https://docs.astral.sh/ruff/rules/line-too-long/
https://docs.astral.sh/ruff/settings/#lint_pycodestyle_max-line-length
